### PR TITLE
Remove duplicate future work section

### DIFF
--- a/analytic-nw-bw.md
+++ b/analytic-nw-bw.md
@@ -128,9 +128,3 @@ For larger $n$, Epanechnikov analytic MSE converges to grid’s values.
 * Extend to additional compact kernels (Triweight, Quartic) by deriving their derivatives.
 * Multivariate smoothing via product or full-covariance kernels.
 * Formal convergence analysis under general conditions.
-
-**9. Future Work**
-
-* Extend to additional compact kernels (Triweight, Quartic) by deriving their derivatives.
-* Multivariate smoothing via product or full-covariance kernels.
-* Formal convergence analysis under general conditions.


### PR DESCRIPTION
## Summary
- remove redundant duplicate "Future Work" section from analytic-nw-bw.md

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a22c9d684c832f854282185790aa25